### PR TITLE
24 hour token lockup notice

### DIFF
--- a/components/stake/depositStake.tsx
+++ b/components/stake/depositStake.tsx
@@ -242,6 +242,10 @@ export default function DepositStake() {
         >
           {depositInput.hasValue ? 'Complete Staking' : 'Enter an amount'}
         </Button>
+        
+        <p className="h-5 text-sm text-gray-300">
+          Your tokens will be locked for 24 hours before you can withdraw them
+        </p>
       </div>
     </form>
   );


### PR DESCRIPTION
I tried withdrawing my tokens right after depositing them and it failed with "Internal JSON-RPC error".

I asked on TG and turns out there is an initial 24 hour lockup.
Adding a note about that is the least we can do to help users like me.